### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.51.0"
 edition = "2021"
 description = "A minimal and fast template engine."
 license = "MIT"
+repository = "https://github.com/jmkng/ban"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
to let crates.is, rust-digger and others to link to it
